### PR TITLE
Fix URL report generation for wikitext links

### DIFF
--- a/cmd/plumb.go
+++ b/cmd/plumb.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"path/filepath"
 
+	"9fans.net/go/acme"
+	"github.com/rjkroege/gozen"
 	"github.com/rjkroege/wikitools/corpus/search"
 	"github.com/rjkroege/wikitools/wiki"
-	"github.com/rjkroege/gozen"
-	"9fans.net/go/acme"
 )
 
 func PlumberHelper(settings *wiki.Settings, lsd, wikitext string) {
@@ -40,7 +40,7 @@ const logfile = "+Wikierror"
 func writewikierror(settings *wiki.Settings, text []byte) error {
 	// shove stuff into Edwood/Acme error area
 	fn := filepath.Join(settings.Wikidir, logfile)
-	
+
 	// Two choices: we already have the Window open.
 	wins, err := acme.Windows()
 	if err != nil {

--- a/cmd/plumb.go
+++ b/cmd/plumb.go
@@ -34,7 +34,6 @@ func PlumberHelper(settings *wiki.Settings, lsd, wikitext string) {
 	gozen.Editinacme(fp)
 }
 
-
 const logfile = "+Wikierror"
 
 // writewikierror appends text to the special file for wiki errors.

--- a/corpus/links.go
+++ b/corpus/links.go
@@ -81,8 +81,8 @@ func MakeWikilinkFromPathPair(frompath, topath string) Wikilink {
 // LinkToFile is implemented by objects that can return a unique or all file paths corresponding
 // to a given wikilink.
 type LinkToFile interface {
-// Returns a single unique path corresponding to the wikitext with
-// location (i.e. root) and found in file lsd.
+	// Returns a single unique path corresponding to the wikitext with
+	// location (i.e. root) and found in file lsd.
 	Path(location, lsd, wikitext string) (string, error)
 
 	// Returns all (absolute) paths in the wiki that would match wikitext.
@@ -160,8 +160,8 @@ func MakeLinks(mapper LinkToFile, location string) *Links {
 		BackLinks:    make(map[string]map[Wikilink]Empty),
 		OutUrls:      make(map[string]map[Urllink]Empty),
 		DamagedLinks: make(map[string]map[Wikilink]Empty),
-		mapper: mapper,
-		location: location,
+		mapper:       mapper,
+		location:     location,
 	}
 }
 

--- a/corpus/links.go
+++ b/corpus/links.go
@@ -142,15 +142,20 @@ type Links struct {
 	OutUrls map[string]map[Urllink]Empty
 
 	// Forward wikitext links that do not unambiguously refer to a specific target.
+	// TODO(rjk): I should track *why* they're damaged.
 	DamagedLinks map[string]map[Wikilink]Empty
+
+	// mapper instance takes a wikitext link to its corresponding filename.
+	mapper LinkToFile
 }
 
-func MakeLinks() *Links {
+func MakeLinks(mapper LinkToFile) *Links {
 	return &Links{
 		ForwardLinks: make(map[string]map[Wikilink]Empty),
 		BackLinks:    make(map[string]map[Wikilink]Empty),
 		OutUrls:      make(map[string]map[Urllink]Empty),
 		DamagedLinks: make(map[string]map[Wikilink]Empty),
+		mapper: mapper,
 	}
 }
 

--- a/corpus/search/nameindex_darwin.go
+++ b/corpus/search/nameindex_darwin.go
@@ -22,8 +22,7 @@ type spotlightWikilinkIndexer struct {
 
 var _ corpus.LinkToFile = (*spotlightWikilinkIndexer)(nil)
 
-func (spix *spotlightWikilinkIndexer) Path(location, fpath, wikitext string) (string, error) {
-	lsd := filepath.Base(fpath)
+func (spix *spotlightWikilinkIndexer) Path(location, lsd, wikitext string) (string, error) {
 	basepart := filepath.Base(wikitext)
 	if basepart == "" {
 		return "", EmptyWikitextFile

--- a/corpus/search/nameindex_darwin.go
+++ b/corpus/search/nameindex_darwin.go
@@ -48,6 +48,7 @@ func (_ *spotlightWikilinkIndexer) Allpaths(location, lsd, wikitext string) ([]s
 func (_ *spotlightWikilinkIndexer) pathsforwikitext(location, wikitextfile string) ([]string, error) {
 	log.Println("Allpaths: the goroutine")
 	waiterchan := make(chan foundation.MetadataQuery)
+	// See [File Metadata Search Programming Guide](https://developer.apple.com/library/archive/documentation/Carbon/Conceptual/SpotlightQuery/Concepts/QueryFormat.html#//apple_ref/doc/uid/TP40001849-CJBEJBHH) for how to configure this string.
 	qs := fmt.Sprintf("kMDItemFSName == '%s'", wikitextfile)
 	predicate := foundation.Predicate_PredicateFromMetadataQueryString(qs)
 

--- a/corpus/tidy/url_report.go
+++ b/corpus/tidy/url_report.go
@@ -43,7 +43,7 @@ func NewUrlReporter(settings *wiki.Settings) (corpus.Tidying, error) {
 	}
 	return &urlReport{
 		settings: settings,
-		links:    corpus.MakeLinks(search.MakeWikilinkNameIndex()),
+		links:    corpus.MakeLinks(search.MakeWikilinkNameIndex(), settings.Wikidir),
 		tmpl:     tmpl,
 	}, nil
 }

--- a/corpus/tidy/url_report.go
+++ b/corpus/tidy/url_report.go
@@ -18,8 +18,8 @@ import (
 	// TODO(rjk): Support parsing math.
 	//	mathjax "github.com/litao91/goldmark-mathjax"
 	"github.com/rjkroege/wikitools/article/wikiextension"
-	"go.abhg.dev/goldmark/wikilink"
 	"github.com/rjkroege/wikitools/corpus/search"
+	"go.abhg.dev/goldmark/wikilink"
 )
 
 type urlReport struct {
@@ -147,7 +147,7 @@ func (abc *urlReport) Summary() error {
 	}
 	for k, v := range abc.links.DamagedLinks {
 		for u := range v {
-			articles[k] = append(articles[k], "*damaged* " + u.Markdown())
+			articles[k] = append(articles[k], "*damaged* "+u.Markdown())
 		}
 	}
 

--- a/corpus/tidy/url_report.go
+++ b/corpus/tidy/url_report.go
@@ -19,6 +19,7 @@ import (
 	//	mathjax "github.com/litao91/goldmark-mathjax"
 	"github.com/rjkroege/wikitools/article/wikiextension"
 	"go.abhg.dev/goldmark/wikilink"
+	"github.com/rjkroege/wikitools/corpus/search"
 )
 
 type urlReport struct {
@@ -42,7 +43,7 @@ func NewUrlReporter(settings *wiki.Settings) (corpus.Tidying, error) {
 	}
 	return &urlReport{
 		settings: settings,
-		links:    corpus.MakeLinks(),
+		links:    corpus.MakeLinks(search.MakeWikilinkNameIndex()),
 		tmpl:     tmpl,
 	}, nil
 }


### PR DESCRIPTION
- Add a LinkToFile mapper instnace to the Links database
- Generate url reports for wikitext links
- Fix url report generation for links without extensions
- Ran gofmt
